### PR TITLE
#76: Read markdown content from std input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "md2bg",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1920,11 +1920,9 @@
       }
     },
     "commander": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
-      "dev": true,
-      "optional": true
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
+      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -6175,6 +6173,15 @@
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "unherit": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "md2bg",
   "description": "convert markdown syntax to backlog syntax",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "author": "37108",
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "commander": "^4.0.1",
     "remark-breaks": "^1.0.3",
     "remark-parse": "^7.0.1",
     "unified": "^8.3.2"

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -2,21 +2,38 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { md2bg } from '../'
+import { Command } from 'commander'
+
+const program = new Command()
+
+const readFromStdin = () => {
+  const content = fs.readFileSync('/dev/stdin', 'utf8')
+  const res = md2bg(content, false)
+  console.log(res)
+  return
+}
 
 const main = () => {
-  if (process.argv.length < 3) {
+  program
+    .option('-s, --stdin', 'read standard input')
+    .parse(process.argv)
+  if (program.stdin) {
+    readFromStdin()
+    return
+  }
+  if (program.args.length == 0) {
     console.log('need file path args')
     console.log('npx md2bg <file path>')
     return
   }
-  const file = process.argv[2]
+  const file = program.args[0]
   try {
     fs.statSync(path.resolve(file))
   } catch {
     console.log(`no such a file: ${file}`)
     return
   }
-  const res = md2bg(file)
+  const res = md2bg(file, true)
   console.log(res)
 }
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import * as fs from 'fs'
 import * as path from 'path'
-import { md2bg } from '../'
 import { Command } from 'commander'
+
+import { md2bg } from '../'
 
 const program = new Command()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,17 +6,31 @@ import breaks from 'remark-breaks'
 
 import { traversal } from './traversal'
 
-const parser = (file: string): any => {
+const readFile = (file: string): string => {
   const filePath = path.resolve(file)
-  const content = fs.readFileSync(filePath, 'utf-8')
+  return fs.readFileSync(filePath, 'utf-8')
+}
+
+const parser = (content: string): any => {
   const processor = unified()
     .use(markdown, {})
     .use(breaks)
   return processor.parse(content)
 }
 
-const md2bg = (file: string) => {
-  const ast = parser(file)
+/**
+ * Convert Markdown document to Backlog format
+ * @param {string} mdData file path or Markdown content
+ * @param {boolean} isFileName whether mdData is file name or not
+ */
+const md2bg = (mdData: string, isFileName: boolean) => {
+  let content: string
+  if (isFileName) {
+    content = readFile(mdData)
+  } else {
+    content = mdData
+  }
+  const ast = parser(content)
   return ast.children.map(item => traversal(item)).join('\n')
 }
 


### PR DESCRIPTION
Closes #76 

[tj/commander\.js](https://github.com/tj/commander.js/) を使って `-s` または `--stdin` オプションで標準入力を読み込めるようにしました。